### PR TITLE
Codacy integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ install: true
 dist: trusty
 
 before_install:
+  - sudo apt-get update
   - sudo apt-get install jq
   - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ before_install:
   - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
 
 after_success:
-- gradle jacocoRootReport
-- java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r build/reports/jacoco/test/jacocoRootReport.xml
+- gradle jacocoRootReport 
+- java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
 
 before_deploy:
         - "./gradlew assemble website"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: java
 install: true
 dist: trusty
+
+before_install:
+  - sudo apt-get install jq
+  - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
+
 after_success:
-- "./gradlew coveralls"
+- gradle jacocoRootReport
+- java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
 
 before_deploy:
         - "./gradlew assemble website"
@@ -19,10 +25,9 @@ deploy:
             tags: true
         - provider: pages
           skip-cleanup: true
-          api_key:
-            secure: dEolMpa639YJvocR44Qltm3SJ3AyFMNL9W8/ODwI1xI5lmZv4uMVkiiy6YWMjsphvq1+ATNv11fXcHRCCaQyP4Tddz43TLzUhvaOKBfPagnT0N/9mUkUX3XbzaIWT+9kqO9XdcqkLJbppF4Xj/p3ICivwENvqbarQjPzAAUpVax/LLxhf5rMErdktJu1nmd57YJdBElZyq5j4lYzUvXoLNyTuEc7DOKZwPAUGk8qvqcofVbDdoR4obk4y/LsuApf967y6+Re/4I7kcNVNYF4UfA/sGSd5O4yRp5VjpP2UAsYy6D965fCafCVIEb7xobgoIluwp7jbCRSA9PrK/jfvfD0BLKQgVpTSoBItOZMhggrSfdDmE0xn/y9GLcGIscjvaYxmSn0/5TTwhQgFQza9YXSozRZlCzbSjZLth8+CbkM09zler01+pi5B0h/QskYTIaIdbWGC8Ux1TrneCN4N1qEJQarfMtbtYh3bq9tNVuDb83r0bqygpioTWd6kdWjV03ECEG4+TufZYtBduBQPi+BbAcN8mlGjXCRulGdMOAtYtOttuvU/vgSWFWoUCIwrqwt/aGN8tjX5l+MwVWWS7SGLjF1J3cUgYde1axEZPKJHzlghtBjH1+UQ9bwpPdNb1Bhy5AI1Iz45nxjvkyhXrOdpYfvUuHH/cM18tdFUr8=
-            # was the following instead of api_key:
-            # github-token:   # Set in travis-ci.org dashboard, marked secure
+#          api_key:
+#            secure: dEolMpa639YJvocR44Qltm3SJ3AyFMNL9W8/ODwI1xI5lmZv4uMVkiiy6YWMjsphvq1+ATNv11fXcHRCCaQyP4Tddz43TLzUhvaOKBfPagnT0N/9mUkUX3XbzaIWT+9kqO9XdcqkLJbppF4Xj/p3ICivwENvqbarQjPzAAUpVax/LLxhf5rMErdktJu1nmd57YJdBElZyq5j4lYzUvXoLNyTuEc7DOKZwPAUGk8qvqcofVbDdoR4obk4y/LsuApf967y6+Re/4I7kcNVNYF4UfA/sGSd5O4yRp5VjpP2UAsYy6D965fCafCVIEb7xobgoIluwp7jbCRSA9PrK/jfvfD0BLKQgVpTSoBItOZMhggrSfdDmE0xn/y9GLcGIscjvaYxmSn0/5TTwhQgFQza9YXSozRZlCzbSjZLth8+CbkM09zler01+pi5B0h/QskYTIaIdbWGC8Ux1TrneCN4N1qEJQarfMtbtYh3bq9tNVuDb83r0bqygpioTWd6kdWjV03ECEG4+TufZYtBduBQPi+BbAcN8mlGjXCRulGdMOAtYtOttuvU/vgSWFWoUCIwrqwt/aGN8tjX5l+MwVWWS7SGLjF1J3cUgYde1axEZPKJHzlghtBjH1+UQ9bwpPdNb1Bhy5AI1Iz45nxjvkyhXrOdpYfvUuHH/cM18tdFUr8=
+          github-token: $GITHUB_TOKEN   # Set in travis-ci.org dashboard, marked secure
           keep-history: true
           local-dir: ./build/website
           on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ before_install:
   - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
 
 after_success:
-- "./gradlew coveralls"
-- gradlew jacocoRootReport 
+- "./gradlew jacocoRootReport coveralls" 
 - java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
-
 
 before_deploy:
         - "./gradlew assemble website"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ before_install:
   - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
 
 after_success:
-- gradle jacocoRootReport 
+- ./gradlew coveralls
+- gradlew jacocoRootReport 
 - java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 
 after_success:
 - gradle jacocoRootReport
-- java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r build/reports/jacoco/test/jacocoRestReport.xml
+- java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r build/reports/jacoco/test/jacocoRootReport.xml
 
 before_deploy:
         - "./gradlew assemble website"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 
 after_success:
 - gradle jacocoRootReport
-- java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
+- java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r build/reports/jacoco/test/jacocoRestReport.xml
 
 before_deploy:
         - "./gradlew assemble website"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,4 @@
-plugins {
-	id 'com.github.kt3k.coveralls' version '2.6.3'
-}
+
 apply plugin: 'base'
 apply plugin: 'application'
 apply plugin: 'eclipse'
@@ -288,16 +286,4 @@ task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
             fileTree(dir: it, exclude: ['ptolemy/**', 'org/opt4j/tutorial/**', 'org/opt4j/viewer/**', 'org/opt4j/core/config/visualization/**'])
         })
     }
-}
-
-coveralls {
-	sourceDirs = subprojects.sourceSets.main.allSource.srcDirs.flatten()
-	jacocoReportPath = "${buildDir}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
-}
-tasks.coveralls {
-  group = 'Documentation'
-  description = 'Uploads the aggregated coverage report to Coveralls'
-
-  dependsOn jacocoRootReport
-  onlyIf { System.env.'CI' && !JavaVersion.current().isJava9Compatible() }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
-
+plugins {
+	id 'com.github.kt3k.coveralls' version '2.6.3'
+}
 apply plugin: 'base'
 apply plugin: 'application'
 apply plugin: 'eclipse'
@@ -286,4 +288,16 @@ task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
             fileTree(dir: it, exclude: ['ptolemy/**', 'org/opt4j/tutorial/**', 'org/opt4j/viewer/**', 'org/opt4j/core/config/visualization/**'])
         })
     }
+}
+
+coveralls {
+	sourceDirs = subprojects.sourceSets.main.allSource.srcDirs.flatten()
+	jacocoReportPath = "${buildDir}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
+}
+tasks.coveralls {
+  group = 'Documentation'
+  description = 'Uploads the aggregated coverage report to Coveralls'
+
+  dependsOn jacocoRootReport
+  onlyIf { System.env.'CI' && !JavaVersion.current().isJava9Compatible() }
 }


### PR DESCRIPTION
Adjusted the travis.yml file to integrate codacy. Codacy is a CI - framework for a visualization of code quality and test coverage, very similar to Sonarqube. You can view the results at 

https://app.codacy.com/projects

As soon as we integrate it, we also will receive messages about the coverage and the code quality changes brought by pull requests (both here and in Slack). So it is like coveralls, but also provides a code quality analysis.

I am quite sure that my changes to the travis.yml get codacy to work and supply it with our coverage data. However, I have no idea how the whole Maven stuff works. It would be great if you would check whether there could be any problems.

I also added some test for the SelectMapGenotype while playing around.