### PR TITLE
Enable integration as gradle subproject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,13 +163,13 @@ uploadArchives.doFirst {
 }
 
 dependencies {
-	runtime project(':opt4j-core')
-	runtime project(':opt4j-satdecoding')
-	runtime project(':opt4j-operators')
-	runtime project(':opt4j-optimizers')
-	runtime project(':opt4j-benchmarks')
-	runtime project(':opt4j-viewer')
-	runtime project(':opt4j-tutorial')
+	runtime project('opt4j-core')
+	runtime project('opt4j-satdecoding')
+	runtime project('opt4j-operators')
+	runtime project('opt4j-optimizers')
+	runtime project('opt4j-benchmarks')
+	runtime project('opt4j-viewer')
+	runtime project('opt4j-tutorial')
 }
 
 jar {
@@ -213,8 +213,8 @@ task copyJavadoc(type: Copy, dependsOn: 'copyJavadocStyle'){
 	into 'build/website/javadoc/'+version
 }
 
-task copyTutorial(type: Copy, dependsOn: ":opt4j-tutorial:tutorial"){
-	from new File(project(':opt4j-tutorial').buildDir,'tutorial')
+task copyTutorial(type: Copy, dependsOn: "opt4j-tutorial:tutorial"){
+	from new File(project('opt4j-tutorial').buildDir,'tutorial')
 	into 'build/website/documentation/'+version
 }
 

--- a/opt4j-benchmarks/build.gradle
+++ b/opt4j-benchmarks/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-	compile project(':opt4j-core')
-	compile project(':opt4j-satdecoding')
+	compile parent.project('opt4j-core')
+	compile parent.project('opt4j-satdecoding')
 }

--- a/opt4j-operators/build.gradle
+++ b/opt4j-operators/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-	compile project(':opt4j-core')
+	compile parent.project('opt4j-core')
 }

--- a/opt4j-optimizers/build.gradle
+++ b/opt4j-optimizers/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-	compile project(':opt4j-core')
-	compile project(':opt4j-operators')
+	compile parent.project('opt4j-core')
+	compile parent.project('opt4j-operators')
 	
 	testCompile	group: 'junit',			  name: 'junit',		   version: '[4.0,)'
 	testCompile group: 'org.mockito',     name: 'mockito-all',     version: '1.9.5'

--- a/opt4j-satdecoding/build.gradle
+++ b/opt4j-satdecoding/build.gradle
@@ -2,7 +2,7 @@ dependencies {
 	compile group: 'org.ow2.sat4j', name: 'org.ow2.sat4j.core', version: '2.3.3'
 	compile group: 'org.ow2.sat4j', name: 'org.ow2.sat4j.pb', version: '2.3.3'
 	
-	compile project(':opt4j-core')
+	compile parent.project('opt4j-core')
 	
 	testCompile group: 'junit', name: 'junit', version: '[4.0,)'
 }

--- a/opt4j-tutorial/build.gradle
+++ b/opt4j-tutorial/build.gradle
@@ -2,11 +2,11 @@ import org.apache.tools.ant.filters.*
 import java.util.regex.*
 
 dependencies {
-	compile project(':opt4j-core')
-	compile project(':opt4j-satdecoding')
-	compile project(':opt4j-optimizers')
-	compile project(':opt4j-operators')
-	compile project(':opt4j-viewer')
+	compile parent.project('opt4j-core')
+	compile parent.project('opt4j-satdecoding')
+	compile parent.project('opt4j-optimizers')
+	compile parent.project('opt4j-operators')
+	compile parent.project('opt4j-viewer')
 }
 
 task filterSources(type: Copy) {

--- a/opt4j-viewer/build.gradle
+++ b/opt4j-viewer/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compile project(':opt4j-core')
+	compile parent.project('opt4j-core')
 }
 
 javadoc {


### PR DESCRIPTION
Use relative project dependencies to enable integration of the opt4j project as a subproject of a top project.