### PR TITLE
fixed bug in the e-dominance script

### DIFF
--- a/src/distribution/bin/batch.py
+++ b/src/distribution/bin/batch.py
@@ -458,8 +458,10 @@ def doResults(basefolder):
     zenit = getMin(zenit)
     
     # adjust nadir in case an objective is equal for nadir and zenit
-    nadmin = [x if x < y else x + 1 for x, y in zip(nadir.minvalues, zenit.minvalues)]
-    nadir = Sample(Sample.invValues(nadmin));
+    # the values are inverted at this point (all Objectives are to be minimized) => in the normal case, x, the nadir
+    # value, has to be worse, that is bigger
+    nadmin = [x if x > y else x + 1 for x, y in zip(nadir.minvalues, zenit.minvalues)]
+    nadir = Sample(Sample.invValues(nadmin))
     
     global gNadir
     gNadir = nadir.values


### PR DESCRIPTION
After another look, I do think we have a bug in the script after all.

The bug is the inequality sign in line 462, which should be pointing the other way round. 

Here is the reasoning behind the correction:

- The purpose of the line is to prevent the case where the nadir (worst value) and the zenit (best value) are equal in order to prevent a possible division by 0 later on
- For that, we iterate the values and assign the nadir to x and the zenit to y
- However, at this point, the data has already been converted into Sample objects, automatically converting all objectives into MIN objectives
- In the normal case, x (the nadir), therefore has to be bigger (worse for a MIN objective) than the y (the zenit)

Could you please have a look and tell me if I'am wrong?